### PR TITLE
Remove '-role' from install

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Run the following commands to install the service:
 $ cd myproject
 
 # Install the service
-$ ansible-container install awasilyev.apache-container-role 
+$ ansible-container install awasilyev.apache-container
 ```
 
 Post Install


### PR DESCRIPTION
Fix the install command.  Galaxy automatically removes `-role` from the end of the name.